### PR TITLE
Fix ble status led

### DIFF
--- a/application/main/src/ble/ble_services.c
+++ b/application/main/src/ble/ble_services.c
@@ -208,7 +208,7 @@ static void pm_evt_handler(pm_evt_t const * p_evt)
 
     switch (p_evt->evt_id)
     {
-        case PM_EVT_CONN_SEC_SUCCEEDED:
+        case PM_EVT_BONDED_PEER_CONNECTED:
             m_peer_id = p_evt->peer_id;
             event_handler(USER_BLE_CONNECTED);
             break;


### PR DESCRIPTION
Fix a Bluetooth status light display issue when pairing code connection is not enabled