### PR TITLE
fix config override issue

### DIFF
--- a/application/main/src/keyboard/keyboard_bootcheck.c
+++ b/application/main/src/keyboard/keyboard_bootcheck.c
@@ -18,8 +18,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <stdint.h>
 
 #include "../main.h"
-#include "bootmagic.h"
 #include "config.h"
+#include "bootmagic.h"
 #include "hook.h"
 #include "keycode.h"
 #include "nrf_delay.h"


### PR DESCRIPTION
This PR fixes the issue that bootmagic macros cannot be overridden by _config.h_ from a keyboard firmware.