### PR TITLE
拆分battery检测与bas service

### DIFF
--- a/application/main/project/kbd.mk
+++ b/application/main/project/kbd.mk
@@ -27,6 +27,7 @@ SRC_FILES += $(APP_SRC_DIR)/keyboard/keyboard_matrix.c \
     $(APP_SRC_DIR)/protocol/hid_configuration.c \
     $(APP_SRC_DIR)/keyboard/sleep_reason.c \
     $(APP_SRC_DIR)/keyboard/keyboard_evt.c \
+    $(APP_SRC_DIR)/keyboard/keyboard_battery.c \
     $(APP_SRC_DIR)/keyboard/store_config.c \
     $(APP_SRC_DIR)/protocol/usb_comm.c \
     $(APP_SRC_DIR)/protocol/ble_comm.c \

--- a/application/main/src/ble/ble_bas_service.c
+++ b/application/main/src/ble/ble_bas_service.c
@@ -18,20 +18,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "ble_bas_service.h"
 #include <string.h>
 
-#include "action.h"
-
 #include "ble_bas.h"
 #include "ble_config.h"
+#include "keyboard_battery.h"
+#include "keyboard_evt.h"
 
 #include "../config/keyboard_config.h"
-#include "adc_convert.h"
 
-#define ADC_BUFFER_SIZE 6
-struct BatteryInfo battery_info;
 BLE_BAS_DEF(m_bas); /**< Structure used to identify the battery service. */
-
-uint16_t adc_buffer[ADC_BUFFER_SIZE];
-uint8_t adc_buffer_index;
 
 /**@brief Function for performing a battery measurement, and update the Battery Level characteristic in the Battery Service.
  */
@@ -47,7 +41,7 @@ static void battery_level_update(uint8_t battery_level)
 
 /**@brief Function for initializing Battery Service.
  */
-static void bas_init(void)
+void battery_service_init(void)
 {
     ret_code_t err_code;
     ble_bas_init_t bas_init_obj;
@@ -67,86 +61,21 @@ static void bas_init(void)
     APP_ERROR_CHECK(err_code);
 }
 
-static void calculate_battery_persentage(struct BatteryInfo* info)
+static void battery_service_event_handler(enum user_event event, void* arg)
 {
-    if (info->voltage >= 4100)
-        info->percentage = 100;
-    else if (info->voltage >= 3335)
-        info->percentage = 15 + (info->voltage - 3335) / 9;
-    else if (info->voltage >= 2900)
-        info->percentage = (info->voltage - 2900) / 29;
-    else
-        info->percentage = 0;
-}
-
-static void adc_result_handler(nrf_saadc_value_t value)
-{
-    adc_buffer[adc_buffer_index++] = value;
-    if (adc_buffer_index >= ADC_BUFFER_SIZE) {
-        adc_buffer_index = 0;
-
-        uint32_t result = 0;
-        for (uint8_t i = 0; i < ADC_BUFFER_SIZE; i++) {
-            result += adc_buffer[i];
+    switch (event) {
+    case USER_EVT_INTERNAL:
+        switch ((uint32_t)arg) {
+        case INTERNAL_EVT_BATTERY_INFO_REFRESH:
+            battery_level_update(battery_info.percentage);
+            break;
+        default:
+            break;
         }
-        result /= ADC_BUFFER_SIZE;
-        // RESULT = [V(P) – V(N) ] * GAIN/REFERENCE * 2 ^ (RESOLUTION - m)
-        // value  = V_in / 1.2 * 1024
-        // V_in   = V_bat * 2.2 / 12.2
-        battery_info.voltage = result * 1200 * 122 / 1024 / 22;
-        calculate_battery_persentage(&battery_info);
-        battery_level_update(battery_info.percentage);
+        break;
+    default:
+        break;
     }
 }
 
-static nrf_saadc_channel_config_t channel_config = {
-    .resistor_p = NRF_SAADC_RESISTOR_DISABLED,
-    .resistor_n = NRF_SAADC_RESISTOR_DISABLED,
-    .gain = NRF_SAADC_GAIN1_2,
-    .reference = NRF_SAADC_REFERENCE_INTERNAL,
-    .acq_time = NRF_SAADC_ACQTIME_10US,
-    .mode = NRF_SAADC_MODE_SINGLE_ENDED,
-    .burst = NRF_SAADC_BURST_DISABLED,
-    .pin_p = (nrf_saadc_input_t)(BATTERY_ADC_PIN),
-    .pin_n = NRF_SAADC_INPUT_DISABLED
-};
-
-static struct adc_channel_config batt_channel = {
-    .adc_start = 0,
-    .adc_finish = &adc_result_handler,
-    .period = 2000,
-    .config = &channel_config,
-};
-
-ADC_CONVERT_CHANNEL(batt_channel);
-
-void battery_service_init(void)
-{
-    bas_init();
-}
-
-/**
- * @brief 输出电池剩余电量.
- *
- */
-void print_battery_percentage()
-{
-    int digits[10] = { KC_0, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9 };
-    char percentage = battery_info.percentage;
-
-    if (percentage <= 0) {
-        type_code(KC_0);
-    } else if (percentage >= 100) {
-        type_code(KC_O);
-        type_code(KC_K);
-    } else {
-        if (percentage >= 10) {
-            int index10 = (percentage / 10) % 10;
-            int digit10 = digits[index10];
-            type_code(digit10);
-        }
-        int index1 = percentage % 10;
-        int digit1 = digits[index1];
-        type_code(digit1);
-    }
-}
+EVENT_HANDLER(battery_service_event_handler);

--- a/application/main/src/ble/ble_bas_service.h
+++ b/application/main/src/ble/ble_bas_service.h
@@ -2,18 +2,3 @@
 #include <stdint.h>
 
 void battery_service_init(void);
-
-struct BatteryInfo {
-    uint16_t voltage; // 电压 (mv)
-    uint8_t percentage; // 百分比
-};
-
-/**
- * 电量信息
- */
-extern struct BatteryInfo battery_info;
-
-/**@brief 输出电池剩余电量.
- *
- */
-void print_battery_percentage();

--- a/application/main/src/driver/ssd1306/ssd1306_oled.c
+++ b/application/main/src/driver/ssd1306/ssd1306_oled.c
@@ -23,7 +23,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "app_scheduler.h"
 #include "nrf_delay.h"
 
-#include "../../ble/ble_bas_service.h"
+#include "keyboard_battery.h"
 #include "events.h"
 #include "keyboard_evt.h"
 #include "passkey.h"

--- a/application/main/src/events.h
+++ b/application/main/src/events.h
@@ -75,6 +75,7 @@ enum user_event {
  */
 enum internal_event {
     INTERNAL_EVT_GATTS_TX_COMPLETE, // 蓝牙GATTS发送成功（启用加密情况下表示连接成功）
+    INTERNAL_EVT_BATTERY_INFO_REFRESH, //电池电量检测刷新
 };
 
 /**

--- a/application/main/src/keyboard/keyboard_battery.c
+++ b/application/main/src/keyboard/keyboard_battery.c
@@ -1,0 +1,110 @@
+/*
+Copyright (C) 2018,2019 Jim Jiang <jim@lotlab.org>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#include <string.h>
+
+#include "action.h"
+#include "action_util.h"
+#include "keyboard_battery.h"
+
+#include "../config/keyboard_config.h"
+#include "adc_convert.h"
+#include "keyboard_evt.h"
+
+#define ADC_BUFFER_SIZE 6
+struct BatteryInfo battery_info;
+
+uint16_t adc_buffer[ADC_BUFFER_SIZE];
+uint8_t adc_buffer_index;
+
+static void calculate_battery_persentage(struct BatteryInfo* info)
+{
+    if (info->voltage >= 4100)
+        info->percentage = 100;
+    else if (info->voltage >= 3335)
+        info->percentage = 15 + (info->voltage - 3335) / 9;
+    else if (info->voltage >= 2900)
+        info->percentage = (info->voltage - 2900) / 29;
+    else
+        info->percentage = 0;
+}
+
+static void adc_result_handler(nrf_saadc_value_t value)
+{
+    adc_buffer[adc_buffer_index++] = value;
+    if (adc_buffer_index >= ADC_BUFFER_SIZE) {
+        adc_buffer_index = 0;
+
+        uint32_t result = 0;
+        for (uint8_t i = 0; i < ADC_BUFFER_SIZE; i++) {
+            result += adc_buffer[i];
+        }
+        result /= ADC_BUFFER_SIZE;
+        // RESULT = [V(P) – V(N) ] * GAIN/REFERENCE * 2 ^ (RESOLUTION - m)
+        // value  = V_in / 1.2 * 1024
+        // V_in   = V_bat * 2.2 / 12.2
+        battery_info.voltage = result * 1200 * 122 / 1024 / 22;
+        calculate_battery_persentage(&battery_info);
+        trig_event_param(USER_EVT_INTERNAL, INTERNAL_EVT_BATTERY_INFO_REFRESH);
+    }
+}
+
+static nrf_saadc_channel_config_t channel_config = {
+    .resistor_p = NRF_SAADC_RESISTOR_DISABLED,
+    .resistor_n = NRF_SAADC_RESISTOR_DISABLED,
+    .gain = NRF_SAADC_GAIN1_2,
+    .reference = NRF_SAADC_REFERENCE_INTERNAL,
+    .acq_time = NRF_SAADC_ACQTIME_10US,
+    .mode = NRF_SAADC_MODE_SINGLE_ENDED,
+    .burst = NRF_SAADC_BURST_DISABLED,
+    .pin_p = (nrf_saadc_input_t)(BATTERY_ADC_PIN),
+    .pin_n = NRF_SAADC_INPUT_DISABLED
+};
+
+static struct adc_channel_config batt_channel = {
+    .adc_start = 0,
+    .adc_finish = &adc_result_handler,
+    .period = 2000,
+    .config = &channel_config,
+};
+
+ADC_CONVERT_CHANNEL(batt_channel);
+
+/**
+ * @brief 输出电池剩余电量.
+ *
+ */
+void print_battery_percentage()
+{
+    int digits[10] = { KC_0, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9 };
+    char percentage = battery_info.percentage;
+
+    if (percentage <= 0) {
+        type_code(KC_0);
+    } else if (percentage >= 100) {
+        type_code(KC_O);
+        type_code(KC_K);
+    } else {
+        if (percentage >= 10) {
+            int index10 = (percentage / 10) % 10;
+            int digit10 = digits[index10];
+            type_code(digit10);
+        }
+        int index1 = percentage % 10;
+        int digit1 = digits[index1];
+        type_code(digit1);
+    }
+}

--- a/application/main/src/keyboard/keyboard_battery.h
+++ b/application/main/src/keyboard/keyboard_battery.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <stdint.h>
+
+struct BatteryInfo {
+    uint16_t voltage; // 电压 (mv)
+    uint8_t percentage; // 百分比
+};
+
+/**
+ * 电量信息
+ */
+extern struct BatteryInfo battery_info;
+
+/**@brief 输出电池剩余电量.
+ *
+ */
+void print_battery_percentage();

--- a/application/main/src/keyboard/keyboard_command.c
+++ b/application/main/src/keyboard/keyboard_command.c
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "action_layer.h"
 #include "action_util.h"
 #include "app_timer.h"
-#include "ble_bas_service.h"
+#include "keyboard_battery.h"
 #include "ble_services.h"
 #include "bootloader.h"
 #include "command.h"

--- a/application/main/src/keyboard/keyboard_fn.c
+++ b/application/main/src/keyboard/keyboard_fn.c
@@ -25,7 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "host.h"
 #include "keymap.h"
 #include "ble_services.h"
-#include "ble_bas_service.h"
+#include "keyboard_battery.h"
 
 #ifdef NKRO_ENABLE
 


### PR DESCRIPTION
为后续启用2.4G，禁用SD做准备。
添加了事件：INTERNAL_EVT_BATTERY_INFO_REFRESH