### PR TITLE
RGB功能枚举定义移动到 rgb.h 文件

### DIFF
--- a/application/main/src/driver/ws2812/README.md
+++ b/application/main/src/driver/ws2812/README.md
@@ -2,10 +2,12 @@
 
 移植自QMK的WS2812驱动，修改适配NRF52芯片
 
+### 源文件
+- rgb.h
+
 ### 启用配置
 ```
 RGBLIGHT_ENABLE = yes
-
 ```
 
 ### Config 配置项目
@@ -15,5 +17,4 @@ RGBLIGHT_ENABLE = yes
 #define RGBLIGHT_ANIMATIONS  //开启RGB动态灯效
 #define RGB_PWR_PIN 12           //POWER控制针脚-采用P MOS
 #define RGB_PWR_PIN_REVERSE 12   //POWER控制针脚-采用N MOS
-
 ```

--- a/application/main/src/driver/ws2812/rgb.h
+++ b/application/main/src/driver/ws2812/rgb.h
@@ -17,6 +17,20 @@
 #ifndef RGB_H
 #define RGB_H
 
+enum RGBLightFunc {
+    RGBLIGHT_TOGGLE, // 开关
+    RGBLIGHT_MODE_INCREASE, // 模式+
+    RGBLIGHT_MODE_DECREASE, // 模式-
+    RGBLIGHT_HUE_INCREASE, // 色相+
+    RGBLIGHT_HUE_DECREASE, // 色相-
+    RGBLIGHT_SAT_INCREASE, // 饱和度+
+    RGBLIGHT_SAT_DECREASE, // 饱和度-
+    RGBLIGHT_VAL_INCREASE, // 明度+
+    RGBLIGHT_VAL_DECREASE, // 明度-
+    RGBLIGHT_SPEED_INCREASE, // 速度+
+    RGBLIGHT_SPEED_DECREASE, // 速度-
+};
+
 __attribute__((weak))
 void rgblight_toggle(void) {};
 

--- a/application/main/src/driver/ws2812/rgblight_ctrl.c
+++ b/application/main/src/driver/ws2812/rgblight_ctrl.c
@@ -1,20 +1,6 @@
 #include "keyboard_fn.h"
 #include "rgb.h"
 
-enum RGBLightFunc {
-    RGBLIGHT_TOGGLE, // 开关
-    RGBLIGHT_MODE_INCREASE, // 模式+
-    RGBLIGHT_MODE_DECREASE, // 模式-
-    RGBLIGHT_HUE_INCREASE, // 色相+
-    RGBLIGHT_HUE_DECREASE, // 色相-
-    RGBLIGHT_SAT_INCREASE, // 饱和度+
-    RGBLIGHT_SAT_DECREASE, // 饱和度-
-    RGBLIGHT_VAL_INCREASE, // 明度+
-    RGBLIGHT_VAL_DECREASE, // 明度-
-    RGBLIGHT_SPEED_INCREASE, // 速度+
-    RGBLIGHT_SPEED_DECREASE, // 速度-
-};
-
 static void rgblight_fn_handler(keyrecord_t* record, uint8_t id, uint8_t opt)
 {
     if (id == RGBLIGHT_CONTROL && record->event.pressed) {


### PR DESCRIPTION
RGB功能枚举定义移动到 h 文件，方便在 keymap 中引入后通过 ACTION_FUNCTION_OPT 使用