### PR TITLE
USB解决卡BIOS的问题

### DIFF
--- a/usb/endpoints.c
+++ b/usb/endpoints.c
@@ -96,7 +96,7 @@ void EP0_OUT()
         break;
     case SETUP_STATE_OUT:
         // 重置端点状态，等待下次传输
-        EP0_RESET();
+        UEP0_CTRL ^= bUEP_R_TOG;                                     //同步标志位翻转
         usb_state.setup_state = SETUP_IDLE;
         break;
     case SETUP_DATA_OUT:
@@ -104,7 +104,7 @@ void EP0_OUT()
         break;
     default:
         // ERROR
-        EP0_RESET();
+        UEP0_CTRL ^= bUEP_R_TOG;                                     //同步标志位翻转
         usb_state.setup_state = SETUP_IDLE;
         break;
     }


### PR DESCRIPTION
解决部分电脑开机/重启时，卡BIOS启动界面较长时间的问题，如联想小新air、惠普光影精灵5代