### PR TITLE
允许用户自定义蓝牙设备类型

### DIFF
--- a/application/main/src/ble/ble_services.c
+++ b/application/main/src/ble/ble_services.c
@@ -560,7 +560,11 @@ static void gap_params_init(void)
 
     set_device_name();
 
-    err_code = sd_ble_gap_appearance_set(BLE_APPEARANCE_HID_KEYBOARD);
+#ifdef DEVICE_BLE_APPEARANCE
+    err_code = sd_ble_gap_appearance_set(DEVICE_BLE_APPEARANCE);
+#else
+    err_code = sd_ble_gap_appearance_set(BLE_APPEARANCE_GENERIC_HID);
+#endif
     APP_ERROR_CHECK(err_code);
 
     memset(&gap_conn_params, 0, sizeof(gap_conn_params));

--- a/application/main/src/ble/ble_services.c
+++ b/application/main/src/ble/ble_services.c
@@ -560,7 +560,7 @@ static void gap_params_init(void)
 
     set_device_name();
 
-    err_code = sd_ble_gap_appearance_set(BLE_APPEARANCE_GENERIC_HID);
+    err_code = sd_ble_gap_appearance_set(BLE_APPEARANCE_HID_KEYBOARD);
     APP_ERROR_CHECK(err_code);
 
     memset(&gap_conn_params, 0, sizeof(gap_conn_params));


### PR DESCRIPTION
在键盘文件的 config.h 中 定义宏 `DEVICE_BLE_APPEARANCE`

FYI 

- [NRF SDK S132 API: Bluetooth Appearance values](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.s132.api.v6.1.0%2Fgroup___b_l_e___a_p_p_e_a_r_a_n_c_e_s.html)
- [NRF SDK S112 API: Bluetooth Appearance values](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.s112.api.v6.1.0%2Fgroup___b_l_e___a_p_p_e_a_r_a_n_c_e_s.html)