### PR TITLE
支持不基于事件系统的阻塞式主动ADC采样

### DIFF
--- a/application/main/src/keyboard/adc_convert.c
+++ b/application/main/src/keyboard/adc_convert.c
@@ -163,3 +163,19 @@ void adc_init()
     err_code = app_timer_create(&adc_timer, APP_TIMER_MODE_REPEATED, adc_convert);
     APP_ERROR_CHECK(err_code);
 }
+
+/**
+ * @brief 阻塞式读取 ADC 值
+ * 
+ * @param channel_index
+ */
+nrf_saadc_value_t adc_read_sync(uint8_t channel_index)
+{
+    nrf_saadc_value_t result_sync = 0;
+    ret_code_t err_code;
+
+    err_code = nrfx_saadc_sample_convert(channel_index, &result_sync);
+    APP_ERROR_CHECK(err_code);
+
+    return result_sync;
+}

--- a/application/main/src/keyboard/adc_convert.h
+++ b/application/main/src/keyboard/adc_convert.h
@@ -39,3 +39,4 @@ struct adc_channel_config {
 
 void adc_timer_start(void);
 void adc_init(void);
+nrf_saadc_value_t adc_read_sync(uint8_t channel_index);


### PR DESCRIPTION
用法可以完全参考[电池电量检测](https://github.com/Lotlab/nrf52-keyboard/blob/master/application/main/src/keyboard/keyboard_battery.c#L65-L84)来进行ADC注册，需要的时候主动调用`adc_read_sync`函数即可。