### PR TITLE
支持在keymap中覆盖，使用自定义的扫描算法

### DIFF
--- a/application/main/src/keyboard/keyboard_matrix.c
+++ b/application/main/src/keyboard/keyboard_matrix.c
@@ -49,10 +49,6 @@ static uint8_t debouncing = DEBOUNCE_RELOAD;
 static matrix_row_t matrix[MATRIX_ROWS];
 static matrix_row_t matrix_debouncing[MATRIX_ROWS];
 
-static matrix_row_t read_cols(void);
-static void select_row(uint8_t row);
-static void unselect_rows(uint8_t row);
-
 #ifdef ROW_IN
 #define READ_COL(pin) (!nrf_gpio_pin_read(pin))
 #else
@@ -63,7 +59,7 @@ static void unselect_rows(uint8_t row);
  * @brief 初始化键盘阵列
  * 
  */
-void matrix_init(void)
+__attribute__((weak)) void matrix_init(void)
 {
     for (uint_fast8_t i = MATRIX_COLS; i--;) {
 #ifdef ROW_IN
@@ -74,7 +70,7 @@ void matrix_init(void)
     }
 }
 /** read all rows */
-static matrix_row_t read_cols(void)
+__attribute__((weak)) matrix_row_t read_cols(void)
 {
     matrix_row_t result = 0;
 
@@ -86,7 +82,7 @@ static matrix_row_t read_cols(void)
     return result;
 }
 
-static void select_row(uint8_t row)
+__attribute__((weak)) void select_row(uint8_t row)
 {
     if ((uint32_t)row_pin_array[row] > 31 )
         return;
@@ -108,7 +104,7 @@ nrf_gpio_cfg(
 #endif
 }
 
-static void unselect_rows(uint8_t row)
+__attribute__((weak)) void unselect_rows(uint8_t row)
 {
     if ((uint32_t)row_pin_array[row] > 31 )
         return;
@@ -133,7 +129,7 @@ static inline void delay_us(void)
     }
 }
 
-uint8_t matrix_scan(void)
+__attribute__((weak)) uint8_t matrix_scan(void)
 {
     for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
         select_row(i);
@@ -165,7 +161,7 @@ uint8_t matrix_scan(void)
     return 1;
 }
 
-bool matrix_is_modified(void)
+__attribute__((weak)) bool matrix_is_modified(void)
 {
     if (debouncing)
         return false;
@@ -245,7 +241,7 @@ uint8_t matrix_key_count(void)
  * @brief 禁用所有阵列针脚
  * 
  */
-void matrix_deinit(void)
+__attribute__((weak)) void matrix_deinit(void)
 {
     for (uint8_t i = 0; i < MATRIX_COLS; i++) {
         nrf_gpio_cfg_default(column_pin_array[i]);
@@ -259,7 +255,7 @@ void matrix_deinit(void)
  * @brief 阵列准备睡眠
  * 
  */
-void matrix_wakeup_prepare(void)
+__attribute__((weak)) void matrix_wakeup_prepare(void)
 {
 // 这里监听所有按键作为唤醒按键，所以真正的唤醒判断应该在main的初始化过程中
 #ifdef ROW_IN

--- a/application/main/src/keyboard/keyboard_matrix.h
+++ b/application/main/src/keyboard/keyboard_matrix.h
@@ -1,6 +1,13 @@
 #pragma once
 #include <stdint.h>
+#include "matrix.h"
 
+void matrix_init(void);
+matrix_row_t read_cols(void);
+void select_row(uint8_t row);
+void unselect_rows(uint8_t row);
+uint8_t matrix_scan(void);
+bool matrix_is_modified(void);
 void matrix_deinit(void);
 void matrix_wakeup_prepare(void);
 


### PR DESCRIPTION
以下函数增加 `__attribute__((weak))` 标注，可以在 keymap 中覆盖实现

```
__attribute__((weak)) void matrix_init(void)
__attribute__((weak)) matrix_row_t read_cols(void)
__attribute__((weak)) void select_row(uint8_t row)
__attribute__((weak)) void unselect_rows(uint8_t row)
__attribute__((weak)) uint8_t matrix_scan(void)
__attribute__((weak)) bool matrix_is_modified(void)
__attribute__((weak)) void matrix_deinit(void)
__attribute__((weak)) void matrix_wakeup_prepare(void)
```